### PR TITLE
Fix dataset reference typo

### DIFF
--- a/dataset_configs.json
+++ b/dataset_configs.json
@@ -84,7 +84,7 @@
         "num_labels": 6
     }, 
     "JyotiNayak/political_ideologies": {
-        "dataset reference": "GPT Political Idealogy",
+        "dataset reference": "GPT Political Ideology",
         "text_field": "statement",
         "label_field": "label",
         "time_field": "",


### PR DESCRIPTION
## Summary
- correct a spelling error in GPT dataset reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684061424d30832bb8bf3c732c4ff36c