### PR TITLE
Add MC continuous mean to CSV saver

### DIFF
--- a/monte_carlo_module.py
+++ b/monte_carlo_module.py
@@ -106,8 +106,10 @@ class MonteCarloDropoutCSVDataSaver(SentimentCSVDataSaver):
             mean_vals = []
             std_vals = []
             for r in mc_results:
+                mean_vals.append(r["mc_mean"])
                 std_vals.append(r["mc_std"])
 
+            df["MC Continuous Mean"] = mean_vals
             df["MC Continuous Std"] = std_vals
 
         else:


### PR DESCRIPTION
## Summary
- enhance MonteCarloDropoutCSVDataSaver to store Monte Carlo mean values for continuous predictions

## Testing
- `python -m py_compile monte_carlo_module.py`


------
https://chatgpt.com/codex/tasks/task_e_6840613d1684832b992ec291d3ca20e7