### PR TITLE
Fix line graph generation condition

### DIFF
--- a/main.py
+++ b/main.py
@@ -311,7 +311,10 @@ if __name__ == "__main__":
                     histogram.save_png(filename)
                 fig_counter += 1
 
-        if generate_line_graph and ('time_field' in data.columns):
+        # The dataset handler stores timestamp information under the "Time"
+        # column. The previous check looked for a literal 'time_field' column,
+        # which does not exist and prevented line graphs from being generated.
+        if generate_line_graph and ('Time' in data.columns):
             line_graph = LineGraphPlot(
                 data=data,
                 fig_counter=fig_counter,


### PR DESCRIPTION
## Summary
- fix column check for time data in line graph generation

## Testing
- `python -m py_compile main.py dataset_handling.py Data_Visualisation.py alb_s1.py bertopic_module.py kcluster_module.py lda_module.py metadata_module.py monte_carlo_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68405fda180c832b8dceee3317ec3b9a